### PR TITLE
Highlight similar cells on double click #44

### DIFF
--- a/src/components/Puzzle/SudokuGridGraphics.tsx
+++ b/src/components/Puzzle/SudokuGridGraphics.tsx
@@ -278,7 +278,8 @@ const useOnGridClick = (cellSize: number, onCellClick: Function | null) => (
     const row = Math.floor(Math.max(0, y - 1) / cellSize)
     const col = Math.floor(Math.max(0, x - 1) / cellSize)
     const ctrl = e.metaKey || e.ctrlKey || e.shiftKey
-    onCellClick?.({ row, col }, ctrl, true)
+    const doubleClick = e.detail === 2
+    onCellClick?.({ row, col }, ctrl, true, doubleClick)
   }, [cellSize, onCellClick])
 )
 

--- a/src/components/Puzzle/hooks.ts
+++ b/src/components/Puzzle/hooks.ts
@@ -49,8 +49,8 @@ export const useControlCallbacks = (isSolvedLoading: boolean) => {
 
   const enabled = !solved && !isSolvedLoading && !paused
 
-  const handleSelectedCellChange = useCallback((cell: CellPosition, ctrl: boolean, isClick: boolean) => {
-    dispatch(changeSelectedCell({ cell, ctrl, isClick }))
+  const handleSelectedCellChange = useCallback((cell: CellPosition, ctrl: boolean, isClick: boolean, doubleClick: boolean) => {
+    dispatch(changeSelectedCell({ cell, ctrl, isClick, doubleClick }))
   }, [dispatch])
   const handleSelectedCellValueChange = useCallback((value: number | null) => {
     dispatch(changeSelectedCellValue(value))
@@ -130,7 +130,7 @@ export const useKeyboardHandler = (isSolvedLoading: boolean) => {
           }
         }
         const ctrl = e.metaKey || e.ctrlKey || e.shiftKey
-        onSelectedCellChange(nextCell, ctrl, false)
+        onSelectedCellChange(nextCell, ctrl, false, false)
         e.preventDefault()
         return
       }

--- a/src/reducers/puzzle.ts
+++ b/src/reducers/puzzle.ts
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import { createSlice } from '@reduxjs/toolkit'
 import formatISO from 'date-fns/formatISO'
 import { CellPosition, Grid, Puzzle } from 'src/types/sudoku'
-import { computeFixedNumbersGrid } from 'src/utils/sudoku'
+import { computeFixedNumbersGrid, getAllCells } from 'src/utils/sudoku'
 import { SudokuLogicalSolveResult } from 'src/types/wasm'
 const jcc = require('json-case-convertor')
 
@@ -114,12 +114,22 @@ export const puzzleSlice = createSlice({
       state.lastUpdate = null
     },
     changeSelectedCell: (state, action) => {
-      const { cell, ctrl, isClick } = action.payload
+      const { cell, ctrl, isClick, doubleClick } = action.payload
       if (ctrl) {
         if (isClick) {
           state.controls.selectedCells = _.xorWith(state.controls.selectedCells, [ cell ], _.isEqual)
         } else {
           state.controls.selectedCells = _.uniqWith([ ...state.controls.selectedCells, cell ], _.isEqual)
+        }
+      } else if (doubleClick) {
+        const value = state.grid![cell.row][cell.col]
+        // Note: the single-click is fired before, so if the there is no digit there
+        // it will be selected
+        if (value !== null) {
+          const cellsWithValue = getAllCells(state.data!.constraints.gridSize).filter(c => (
+            state.grid![c.row][c.col] === value
+          ))
+          state.controls.selectedCells = cellsWithValue
         }
       } else {
         state.controls.selectedCells = [ cell ]


### PR DESCRIPTION
Fixes https://github.com/lisudoku/lisudoku_frontend/issues/44

**Changes**
* When the user double click on a cell with a value it highlights all of the cells with the same value

**After**

<img width="979" alt="Screenshot 2023-02-25 at 14 21 55" src="https://user-images.githubusercontent.com/6545554/221356581-8a139b53-0aa2-438f-8586-ce3d5f2c6a5c.png">

