### PR TITLE
Implement top-bottom variant #36

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://lisudoku.xyz
 
 This is lisudoku's frontend written in React that connects to the Rails [backend](https://github.com/lisudoku/lisudoku_backend).
 
-9 supported sudoku variants.
+10 supported sudoku variants.
 
 ## Contribute
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "date-fns": "^2.29.3",
     "final-form": "^4.20.7",
     "json-case-convertor": "^1.4.0",
-    "lisudoku-solver": "0.1.12",
+    "lisudoku-solver": "0.1.13",
     "lodash": "^4.17.21",
     "lz-string": "^1.4.4",
     "react": "^18.2.0",

--- a/src/components/Puzzle/SudokuRules.tsx
+++ b/src/components/Puzzle/SudokuRules.tsx
@@ -3,7 +3,7 @@ import _ from 'lodash'
 import { SudokuConstraints } from 'src/types/sudoku'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
-  faThermometer4, faXmark, faChessKnight, faSquare, faCircle as faCircleSolid,
+  faThermometer4, faXmark, faChessKnight, faSquare, faCircle as faCircleSolid, faBolt,
 } from '@fortawesome/free-solid-svg-icons'
 import { faCircle, faCircleXmark } from '@fortawesome/free-regular-svg-icons'
 
@@ -89,6 +89,15 @@ const computeRules = (constraints: SudokuConstraints) => {
       <FontAwesomeIcon icon={faSquare} size="sm" color="lightgray" />
       {' '}
       Cells with shaded squares contain even digits.
+    </>)
+  }
+  if (constraints.topBottom) {
+    rules.push(<>
+      <FontAwesomeIcon icon={faBolt} size="sm" color="lightgray" />
+      {' '}
+      There are two sequences of numbers: from digit 1 in top row to digit {constraints.gridSize}
+      {' '} in bottom row and from digit 1 in bottom row to digit {constraints.gridSize} in top row.
+      A sequence has to have consecutive numbers touching by side or corner.
     </>)
   }
   return rules

--- a/src/components/PuzzleBuilder/LogicalSolutionPanel.tsx
+++ b/src/components/PuzzleBuilder/LogicalSolutionPanel.tsx
@@ -46,6 +46,9 @@ const estimateDifficultyByConstraints = (constraints: SudokuConstraints) => {
   nonEmptyCells += constraints.extraRegions.length * 2
   nonEmptyCells += constraints.oddCells.length / 2
   nonEmptyCells += constraints.evenCells.length / 2
+  if (constraints.topBottom) {
+    nonEmptyCells += constraints.gridSize
+  }
 
   if (nonEmptyCells >= 30) {
     return StepRuleDifficultyDisplay[EStepRuleDifficulty.Easy]

--- a/src/components/PuzzleBuilder/index.tsx
+++ b/src/components/PuzzleBuilder/index.tsx
@@ -7,6 +7,7 @@ import { useControlCallbacks, useKeyboardHandler, useSolver } from './hooks'
 import {
   addConstraint, changeAntiKnight, changeConstraintType, changeInputActive, changeKillerSum,
   changeKropkiNegative, changePrimaryDiagonal, changeSecondaryDiagonal,
+  changeTopBottom,
   ConstraintType, initPuzzle, receivedPuzzle, SolverType,
 } from 'src/reducers/builder'
 import Radio from 'src/components/Radio'
@@ -117,6 +118,10 @@ const PuzzleBuilder = ({ admin }: { admin: boolean }) => {
 
   const handleKropkiNegativeChange = useCallback((e: ChangeEvent<HTMLInputElement>) => (
     dispatch(changeKropkiNegative(e.target.checked))
+  ), [dispatch])
+
+  const handleTopBottomChange = useCallback((e: ChangeEvent<HTMLInputElement>) => (
+    dispatch(changeTopBottom(e.target.checked))
   ), [dispatch])
 
   const handleImportClick = useCallback(() => {
@@ -286,6 +291,10 @@ const PuzzleBuilder = ({ admin }: { admin: boolean }) => {
                     label="Kropki Negative"
                     checked={constraints.kropkiNegative}
                     onChange={handleKropkiNegativeChange} />
+          <Checkbox id="top-bottom"
+                    label="Top-Bottom"
+                    checked={constraints.topBottom}
+                    onChange={handleTopBottomChange} />
         </div>
         <hr />
         <div className="flex w-full gap-x-1">

--- a/src/reducers/builder.ts
+++ b/src/reducers/builder.ts
@@ -113,6 +113,9 @@ const detectVariant = (state: BuilderState) => {
   if (!_.isEmpty(state.constraints?.oddCells) || !_.isEmpty(state.constraints?.evenCells)) {
     variants.push(SudokuVariant.OddEven)
   }
+  if (state.constraints?.topBottom) {
+    variants.push(SudokuVariant.TopBottom)
+  }
   if (variants.length > 1) {
     return SudokuVariant.Mixed
   } else if (variants.length === 1) {
@@ -136,6 +139,7 @@ export const defaultConstraints = (gridSize: number) => ({
   antiKnight: false,
   oddCells: [],
   evenCells: [],
+  topBottom: false,
 })
 
 export const builderSlice = createSlice({
@@ -182,19 +186,7 @@ export const builderSlice = createSlice({
       const constraints: Partial<SudokuConstraints> = jcc.camelCaseKeys(action.payload)
       const gridSize = constraints.gridSize!
       state.constraints = {
-        gridSize,
-        fixedNumbers: [],
-        regions: ensureDefaultRegions(gridSize),
-        extraRegions: [],
-        thermos: [],
-        killerCages: [],
-        kropkiDots: [],
-        kropkiNegative: false,
-        primaryDiagonal: false,
-        secondaryDiagonal: false,
-        antiKnight: false,
-        oddCells: [],
-        evenCells: [],
+        ...defaultConstraints(gridSize),
         ...constraints,
       }
       state.difficulty = defaultDifficulty(gridSize)
@@ -499,6 +491,10 @@ export const builderSlice = createSlice({
       state.constraints!.kropkiNegative = action.payload
       handleConstraintChange(state)
     },
+    changeTopBottom(state, action) {
+      state.constraints!.topBottom = action.payload
+      handleConstraintChange(state)
+    },
     changeSourceCollectionId(state, action) {
       state.sourceCollectionId = action.payload
     },
@@ -521,7 +517,7 @@ export const {
   requestAddPuzzle, responseAddPuzzle, errorAddPuzzle,
   toggleNotesActive, changeSelectedCellNotes,
   changePrimaryDiagonal, changeSecondaryDiagonal, changeAntiKnight,
-  changeKillerSum, changeKropkiNegative,
+  changeKillerSum, changeKropkiNegative, changeTopBottom,
   changeInputActive, changeSourceCollectionId, changeSelectedCellConstraint,
   clearBruteSolution, clearLogicalSolution,
 } = builderSlice.actions

--- a/src/screens/AdminPage/PuzzlesPage/PuzzleCardIcons.tsx
+++ b/src/screens/AdminPage/PuzzlesPage/PuzzleCardIcons.tsx
@@ -1,6 +1,6 @@
 import { SudokuConstraints } from 'src/types/sudoku'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faChessKnight } from '@fortawesome/free-solid-svg-icons'
+import { faChessKnight, faBolt } from '@fortawesome/free-solid-svg-icons'
 import { faCircleXmark } from '@fortawesome/free-regular-svg-icons'
 
 const PuzzleCardIcons = ({ constraints }: { constraints: SudokuConstraints }) => (
@@ -10,6 +10,9 @@ const PuzzleCardIcons = ({ constraints }: { constraints: SudokuConstraints }) =>
     )}
     {constraints.kropkiNegative && (
       <div><FontAwesomeIcon icon={faCircleXmark} size="sm" title="Kropki Negative" /></div>
+    )}
+    {constraints.topBottom && (
+      <div><FontAwesomeIcon icon={faBolt} size="sm" title="Top-Bottom" /></div>
     )}
   </div>
 )

--- a/src/screens/HomePage/SudokuVariantCard.tsx
+++ b/src/screens/HomePage/SudokuVariantCard.tsx
@@ -65,7 +65,7 @@ const SudokuVariantCard = ({ variant, difficulty }: { variant: SudokuVariant, di
               <polyline points="10,88 10,65" />
             </g>
           )}
-          {variant === SudokuVariant.TopBot && (
+          {variant === SudokuVariant.TopBottom && (
             <polyline points="75,0 75,15 62,30 62,45 53,53 53,70 40,85 40,100" className="opacity-60" />
           )}
           {variant === SudokuVariant.Classic && (

--- a/src/screens/LearnPage/techniques.tsx
+++ b/src/screens/LearnPage/techniques.tsx
@@ -430,6 +430,13 @@ const TECHNIQUES: Technique[] = [
     ],
     practicePuzzleIds: [ '_Zm0aj0rpHD8tCYTCdZU' ],
   },
+  {
+    id: StepRule.TopBottomCandidates,
+    summary: <>
+      For each row X we track the cells with candidate X where the sequence 1 to X can arrive on.
+      For the decreasing sequence on row X we track digit 10-X.
+    </>,
+  },
 ]
 
 export const TECHNIQUES_BY_DIFFICULTY = _.groupBy(

--- a/src/types/sudoku.ts
+++ b/src/types/sudoku.ts
@@ -14,7 +14,7 @@ export enum SudokuVariant {
   Arrow = 'arrow',
   Irregular = 'irregular',
   Kropki = 'kropki',
-  TopBot = 'topbot',
+  TopBottom = 'topbot',
   Diagonal = 'diagonal',
   Mixed = 'mixed',
   AntiKnight = 'antiknight',
@@ -45,6 +45,7 @@ export type SudokuConstraints = {
   kropkiNegative: boolean
   oddCells: CellPosition[]
   evenCells: CellPosition[]
+  topBottom: boolean
 }
 
 export type FixedNumber = {

--- a/src/types/wasm.ts
+++ b/src/types/wasm.ts
@@ -37,6 +37,7 @@ export enum StepRule {
   Killer45 = 'Killer45',
   Kropki = 'Kropki',
   KropkiChainCandidates = 'KropkiChainCandidates',
+  TopBottomCandidates = 'TopBottomCandidates',
   LockedCandidatesPairs = 'LockedCandidatesPairs',
   NakedPairs = 'NakedPairs',
   HiddenPairs = 'HiddenPairs',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -14,6 +14,7 @@ export const ACTIVE_VARIANTS: SudokuVariant[] = [
   SudokuVariant.Irregular,
   SudokuVariant.ExtraRegions,
   SudokuVariant.OddEven,
+  SudokuVariant.TopBottom,
   SudokuVariant.Mixed,
 ]
 
@@ -26,7 +27,7 @@ export const SudokuVariantDisplay: { [key in SudokuVariant]: string } = {
   [SudokuVariant.Arrow]: 'Arrow',
   [SudokuVariant.Irregular]: 'Irregular',
   [SudokuVariant.Kropki]: 'Kropki',
-  [SudokuVariant.TopBot]: 'Top-Bot',
+  [SudokuVariant.TopBottom]: 'Top-Bottom',
   [SudokuVariant.Diagonal]: 'Diagonal',
   [SudokuVariant.AntiKnight]: 'Anti Knight',
   [SudokuVariant.ExtraRegions]: 'Extra Regions',
@@ -57,6 +58,7 @@ export const StepRuleDisplay: { [key in StepRule]: string } = {
   [StepRule.Killer45]: 'Killer Sum Rule',
   [StepRule.Kropki]: 'Kropki Dot Pair Logic',
   [StepRule.KropkiChainCandidates]: 'Kropki Dot Chain Logic',
+  [StepRule.TopBottomCandidates]: 'Top-Bottom Candidates',
   [StepRule.LockedCandidatesPairs]: 'Locked Candidate Pairs',
   [StepRule.NakedPairs]: 'Naked Pairs',
   [StepRule.HiddenPairs]: 'Hidden Pairs',
@@ -94,6 +96,7 @@ export const StepRuleDifficulty: { [key in StepRule]: EStepRuleDifficulty } = {
   [StepRule.Killer45]: EStepRuleDifficulty.Medium,
   [StepRule.Kropki]: EStepRuleDifficulty.Medium,
   [StepRule.KropkiChainCandidates]: EStepRuleDifficulty.Medium,
+  [StepRule.TopBottomCandidates]: EStepRuleDifficulty.Medium,
   [StepRule.LockedCandidatesPairs]: EStepRuleDifficulty.Medium,
   [StepRule.NakedPairs]: EStepRuleDifficulty.Medium,
   [StepRule.HiddenPairs]: EStepRuleDifficulty.Medium,

--- a/src/utils/import.ts
+++ b/src/utils/import.ts
@@ -240,6 +240,7 @@ const importFpuzzlesPuzzle = (url: string): ImportResult => {
     kropkiNegative: !_.isEmpty(data.negative) && data.nonconsecutive,
     oddCells: (data.odd ?? []).map(({ cell }: { cell: string }) => cellStringToObject(cell)),
     evenCells: (data.even ?? []).map(({ cell }: { cell: string }) => cellStringToObject(cell)),
+    topBottom: false,
   }
 
   let message = 'Puzzle imported'

--- a/src/utils/solver.tsx
+++ b/src/utils/solver.tsx
@@ -87,6 +87,11 @@ const getBigStepExplanation = (step: SolutionStep, hintLevel: HintLevel) => {
       const areaMessage = areaDisplay(step.areas[0])
       return ` in ${areaMessage} on cells ${cells} to only keep ${values}`
     }
+    case StepRule.XWing: {
+      const areaDisplays = step.areas.map(area => areaDisplay(area))
+      return ` on cells ${cells} (${areaDisplays[0]} and ${areaDisplays[1]}) ` +
+        `to remove ${values} from ${affectedCells} (${areaDisplays[2]} and ${areaDisplays[3]})`
+    }
     case StepRule.XYWing:
       const zValue = step.values[2]
       return ` on cells ${cells} to remove ${zValue} from ${affectedCells}`
@@ -103,6 +108,13 @@ const getBigStepExplanation = (step: SolutionStep, hintLevel: HintLevel) => {
         `${cellDisplays[2]}-${cellDisplays[3]}. Because ${cellDisplays[0]} and ${cellDisplays[2]} ` +
         `see each other, at least one of ${cellDisplays[1]} and ${cellDisplays[3]} will be ${values}, so remove ` +
         `${values} from cells ${affectedCells}.`
+    case StepRule.TopBottomCandidates: {
+      const ascending = step.areas[0].Row + 1 === step.values[0]
+      const otherValue = (ascending === (step.areas[0].Row < step.areas[1].Row)) ? step.values[0] + 1 : step.values[0] - 1
+      return ` in ${areaDisplay(step.areas[0])} to remove ${values} from ${affectedCells} because ` +
+        `${step.affected_cells.length !== 1 ? 'they' : 'it'} can't be linked with digit ${otherValue} ` +
+        `on ${areaDisplay(step.areas[1])}`
+    }
     default:
       // Some techniques don't have areas (e.g. XY-Wing)
       const areaMessage = step.areas.length > 0 ? ` in ${areaDisplay(step.areas[0])}` : ''

--- a/src/utils/wasm.ts
+++ b/src/utils/wasm.ts
@@ -16,6 +16,7 @@ export const computeWasmConstraints = (constraints: SudokuConstraints) => {
   wasmConstraints.primary_diagonal ||= false
   wasmConstraints.secondary_diagonal ||= false
   wasmConstraints.anti_knight ||= false
+  wasmConstraints.top_bottom ||= false
   return wasmConstraints
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6490,10 +6490,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-lisudoku-solver@0.1.12:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/lisudoku-solver/-/lisudoku-solver-0.1.12.tgz#e9d53ec3ea1a010954049a1ee3b3190376268b7d"
-  integrity sha512-OcUKOFocdE7qagOIfHR8XbDSKDXfJ06rPHPBZ4Wxa3zrrSaoFhx799GRE6iCcnAr2f9CZkhJ6MDONVNNAtyMnw==
+lisudoku-solver@0.1.13:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/lisudoku-solver/-/lisudoku-solver-0.1.13.tgz#2c09ca47dbc6a2043726c80ab15ec7bb03c4adf5"
+  integrity sha512-6FQuAQb8Rw3WnYg24z/DbYkjGuWNBAES/en2EGdEEYdgAELwv8TlqUyyx3Qncw8PUkaBwyH7abQbW5AuJjLmjA==
 
 loader-runner@^4.2.0:
   version "4.3.0"


### PR DESCRIPTION
Fixes https://github.com/lisudoku/lisudoku_solver/issues/36
Solver PR: https://github.com/lisudoku/lisudoku_solver/pull/56

**Changes**
* Ability to create top-bottom puzzles in puzzle builder
* Top-bottom variant card on the main page
* Hint text for new top-bottom specific solving technique

**After**

<img width="1411" alt="Screenshot 2023-02-26 at 15 45 49" src="https://user-images.githubusercontent.com/6545554/221414366-33e5a660-1e3a-437a-81c5-5916f58a007d.png">

<img width="1167" alt="Screenshot 2023-02-26 at 15 46 07" src="https://user-images.githubusercontent.com/6545554/221414372-f0deda51-1e44-4612-9368-877bf4f2b518.png">

<img width="1140" alt="Screenshot 2023-02-26 at 15 46 44" src="https://user-images.githubusercontent.com/6545554/221414374-89015148-74ec-4499-b984-f784372a652a.png">

<img width="1416" alt="Screenshot 2023-02-26 at 15 46 52" src="https://user-images.githubusercontent.com/6545554/221414381-0a8bdc22-13f1-4612-bd51-1ab76e29b893.png">
